### PR TITLE
Support frontmatter

### DIFF
--- a/Support/bin/redcarpet.rb
+++ b/Support/bin/redcarpet.rb
@@ -40,6 +40,15 @@ def checkbox_html(checked)
   "<li><input type='checkbox' #{"checked" if checked} style='margin-right:0.5em;'/>"
 end
 
+def strip_yaml_frontmatter(text)
+  delimiter = /^---\s*$/
+  lines = text.split("\n")
+  if lines[0] =~ delimiter && (end_of_frontmatter = lines[1..-1].find_index{ |l| l =~ delimiter }) != nil
+    lines.slice!(0, end_of_frontmatter + 1)
+  end
+  lines.join("\n")
+end
+
 def markdown(text)
   options = {
     :filter_html     => true,
@@ -63,4 +72,4 @@ def markdown(text)
 end
 
 puts "<style>#{Pygments.css(:style => "colorful")}</style>"
-puts markdown(ARGF.read)
+puts markdown(strip_yaml_frontmatter(ARGF.read))

--- a/Syntaxes/Markdown (Frontmatter).tmLanguage
+++ b/Syntaxes/Markdown (Frontmatter).tmLanguage
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array/>
+	<key>injectionSelector</key>
+	<string>L:text.html.markdown</string>
+	<key>name</key>
+	<string>Markdown (Frontmatter)</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>begin</key>
+			<string>\A---\s*\n</string>
+			<key>comment</key>
+			<string>This matches a YAML frontmatter block at the beginning of the document.</string>
+			<key>contentName</key>
+			<string>text.html.markdown.yaml</string>
+			<key>end</key>
+			<string>(^|\G)---\s*\n</string>
+			<key>name</key>
+			<string>markup.raw.block.yaml</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.yaml</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>text.html.markdown.github</string>
+	<key>uuid</key>
+	<string>C3C2129B-A61F-49FD-9C13-FC2FCB0A773F</string>
+</dict>
+</plist>


### PR DESCRIPTION
Based on https://github.com/textmate/markdown.tmbundle/issues/27

This is not strictly speaking a feature of “GitHub markdown”, so not sure if you want to include it. I could of course create a dedicated bundle for it, too.

The grammar needs to be injected to have precedence over the default Markdown grammar (which parses `---` as setext header). Therefore I created a new grammar instead of just adding the rules to the “Markdown (GitHub)”.

I also extended the preview command to strip a YAML frontmatter before converting the document to markdown.

I tested several edge cases (frontmatter only, no end delimiter for frontmatter, …) and both highlighting and preview seem to work fine. I’d be happy to support this in the future, too, if any problems should appear.
