### PR TITLE
Add snippet for inserting a code block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Provides some [GitHub Flavoured Markdown](https://help.github.com/articles/githu
 
 ## Features
 - Add a new "Preview" command (overriding the existing Markdown preview) using [Redcarpet](https://github.com/vmg/redcarpet) to render GitHub Flavoured Markdown
-- Support triple-backtick raw blocks and support syntax highlighting for various languages (others can be added trivially)
+- Support triple-backtick raw blocks and support syntax highlighting for various languages (others can be added trivially). There’s also a tab trigger for inserting raw blocks: Just type a single backtick (<kbd>`</kbd>) and then hit the tab key.
 - Support and highlight GitHub Flavoured Markdown strikethroughs, tables, references, checkboxes and italics
 
 You can also use nicer fonts by installing the [GitHub Flavoured Markdown Font Settings bundle](https://github.com/mikemcquaid/GitHub-Markdown-Font-Settings.tmbundle).

--- a/Snippets/Code block.tmSnippet
+++ b/Snippets/Code block.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\`\`\`${1|bash,bib,c,c#,c++,cpp,csharp,css,go,html,inc,java,javascript,jruby,js,latex,macruby,node,php,python,rake,rb,rbx,ruby,rusthon,sh,shell,swift,tex,xhtml,zsh|}
+$0
+\`\`</string>
+	<key>name</key>
+	<string>Insert Code Block</string>
+	<key>tabTrigger</key>
+	<string>`</string>
+	<key>uuid</key>
+	<string>801405C3-C14D-4C1D-8353-AF6A54FED3D8</string>
+</dict>
+</plist>


### PR DESCRIPTION
Tab trigger: <kbd>`⇥</kbd> (that is, a single backtick and then pressing the tab key). Note that typing a single backtick will insert two backticks (with the cursor in between), because the Markdown bundle defines an appropriate smart typing pair. This is why the snippet inserts only two backticks at the end of the code block: Together with the backtick already inserted by the smart typing pair this then gives three backticks at the end.

The snippet shows a completion list for specifying the language of the code block. The list of supported languages was extracted from the bundle’s grammar. If at some point in the future more languages are added to the grammar, these languages should be added to the completion list as well.
