### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,14 @@ Provides some [GitHub Flavoured Markdown](https://help.github.com/articles/githu
 You can also use nicer fonts by installing the [GitHub Flavoured Markdown Font Settings bundle](https://github.com/mikemcquaid/GitHub-Markdown-Font-Settings.tmbundle).
 
 ## Installation
-### TextMate 2
 
 Check "Markdown (GitHub)" in TextMate 2's Preferences' Bundles.
 
 Alternatively:
 ```bash
-mkdir -p ~/Library/Application\ Support/Avian/Bundles
-cd ~/Library/Application\ Support/Avian/Bundles
-git clone https://github.com/mikemcquaid/GitHub-Markdown.tmbundle
-```
-
-### TextMate 1
-```bash
 mkdir -p ~/Library/Application\ Support/TextMate/Bundles
 cd ~/Library/Application\ Support/TextMate/Bundles
 git clone https://github.com/mikemcquaid/GitHub-Markdown.tmbundle
-osascript -e 'tell app "TextMate" to reload bundles'
 ```
 
 ## Status


### PR DESCRIPTION
TextMate 2 no longer uses `Avian/Bundles`.

After updating the installation instructions for TM 2 accordingly, they were identical to the installation instructions for TM 1 (except for the AppleScript snippet to reload all bundles), so I decided to unify both instructions into one single paragraph (not sure if anyone still uses TM 1 anyway).

Fixes #22 