### PR TITLE
The Italic Conundrum

### DIFF
--- a/Syntaxes/Markdown (GitHub Italics).tmLanguage
+++ b/Syntaxes/Markdown (GitHub Italics).tmLanguage
@@ -27,7 +27,7 @@
 				precedence and thus prevent the main Markdown grammar’s pattern for italic text from
 				matching these underscores.)</string>
 			<key>match</key>
-			<string>(_)(?=\w)(?&lt;=\w)</string>
+			<string>(?&lt;=\w)(_)(?=\w)</string>
 			<key>name</key>
 			<string>markup.other</string>
 		</dict>

--- a/Syntaxes/Markdown (GitHub Italics).tmLanguage
+++ b/Syntaxes/Markdown (GitHub Italics).tmLanguage
@@ -7,7 +7,7 @@
 	<key>hideFromUser</key>
 	<true/>
 	<key>injectionSelector</key>
-	<string>(L:text.html.markdown)</string>
+	<string>L:(text.html.markdown - (markup.italic.markdown))</string>
 	<key>name</key>
 	<string>Markdown (GitHub Italics)</string>
 	<key>patterns</key>

--- a/Syntaxes/Markdown (GitHub Italics).tmLanguage
+++ b/Syntaxes/Markdown (GitHub Italics).tmLanguage
@@ -7,7 +7,7 @@
 	<key>hideFromUser</key>
 	<true/>
 	<key>injectionSelector</key>
-	<string>L:(text.html.markdown - (markup.italic.markdown))</string>
+	<string>L:(text.html.markdown - (markup.italic.markdown | markup.bold.markdown))</string>
 	<key>name</key>
 	<string>Markdown (GitHub Italics)</string>
 	<key>patterns</key>

--- a/Syntaxes/Markdown (GitHub Italics).tmLanguage
+++ b/Syntaxes/Markdown (GitHub Italics).tmLanguage
@@ -7,7 +7,7 @@
 	<key>hideFromUser</key>
 	<true/>
 	<key>injectionSelector</key>
-	<string>L:(text.html.markdown - (markup.italic.markdown | markup.bold.markdown))</string>
+	<string>L:(text.html.markdown - (markup.italic.markdown | markup.bold.markdown | markup.raw))</string>
 	<key>name</key>
 	<string>Markdown (GitHub Italics)</string>
 	<key>patterns</key>

--- a/Tests/Italics.mdown
+++ b/Tests/Italics.mdown
@@ -1,0 +1,35 @@
+# Should Match
+
+_italic_
+
+_italic italic_
+
+_italic_regular
+
+
+# Should Not Match
+
+regular_regular_regular
+
+
+# Should Not Match But Does
+
+regular _italic_regular
+
+
+# Other Cases (Should not match)
+
+__double underscores__
+
+    _raw_
+    
+    raw_raw_raw
+
+Lorem `ipsum_dolor_sit` amet
+
+
+# Exceptional Cases
+
+$$y_i = \alpha_{j[i]} + \beta x_i + \epsilon_i$$
+
+This is MathJax code which should be parsed separately, but shows just how loose the main spec is about what can be in italic.


### PR DESCRIPTION
The previous fix for this issue uses the regex:

		(_)(?=\w)(?<=\w)

This puts the look-behind assertion after the `_` looking back, this shouldn't ever match but does due to some quirk of the engine which I don't really understand. I've moved this before the `_` character to make it function as intended.

_Edit: Brain fart moment there, of corse it worked because `_` is a word character, silly me. Regardless, the intent would be to match `\w` before the `_` so it should be moved_.

There are other issues though: The first is due to how the italics rule in the main grammar is done. It uses a look-ahead to ensure that the ending will exist before starting, it can easily be tripped up with the string:

    this _is_invalid

Because the italics rule is entered due it detecting a valid italics context but the injected grammar yanking the closing `_` leaving the context persisting indefinitely.

Started looking into this due to some discussion in textmate/markdown.tmbundle#46 with the MathJax string:

    $$y_i = \alpha_{j[i]} + \beta x_i + \epsilon_i$$

The proper way to handle this specific case I believe is a MathJax grammar, but it was a real world example of the issue.

To improve the issue I've again disabled the rule inside italics contexts, which allows a rule already entered to exit. The rule now only serves to prevent a italics context to be entered in a common invalid context for GitHub's markdown variant.

I think to truly solve this issue a rule would need to be written to wholly match 'word' like constructs that are not desired to be passed through the main italics rule.

An example of where the behavior in this PR fails is the first example again:

    this _is_invalid

Where GitHub does not consider this to be italics as the closing `_` is inside the rule but we can't exclude the case as we are already too late with a simplistic exception that hasn't matched a larger section of the text.

A second issue easily fixed is that it was matching the third `_` in the string:

    __double underscores__

Which prevents the bold context to exit, this has been corrected.

Also corrected is properly excluding embedded and raw cases as it should never match characters in those.

cc @noniq