### PR TITLE
Updated message when redcarpet not installed.It's required to run tha…

### DIFF
--- a/Support/bin/redcarpet.rb
+++ b/Support/bin/redcarpet.rb
@@ -20,7 +20,7 @@ rescue LoadError
   puts <<-EOS
 <p>Please install the Redcarpet and Pygments.rb RubyGems by running the following:</p>
 
-<pre><code>/usr/bin/gem install --user redcarpet pygments.rb</code></pre>
+<pre><code>sudo /usr/bin/gem install --user redcarpet pygments.rb</code></pre>
 EOS
   exit 0
 end


### PR DESCRIPTION
Users should run redcarpet install command in sudo mode, otherwise will fail
```
hfli@CNhfli ~/Documents $ /usr/bin/gem install --user redcarpet pygments.rb
WARNING:  You don't have /Users/hfli/.gem/ruby/2.3.0/bin in your PATH,
	  gem executables will not run.
Building native extensions.  This could take a while...
ERROR:  Error installing redcarpet:
	ERROR: Failed to build gem native extension.

    current directory: /Users/hfli/.gem/ruby/2.3.0/gems/redcarpet-3.4.0/ext/redcarpet
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -r ./siteconf20180206-4334-x7jsup.rb extconf.rb
mkmf.rb can't find header files for ruby at /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/include/ruby.h

extconf failed, exit code 1

Gem files will remain installed in /Users/hfli/.gem/ruby/2.3.0/gems/redcarpet-3.4.0 for inspection.
Results logged to /Users/hfli/.gem/ruby/2.3.0/extensions/universal-darwin-17/2.3.0/redcarpet-3.4.0/gem_make.out
Successfully installed pygments.rb-1.2.1
Parsing documentation for pygments.rb-1.2.1
Done installing documentation for pygments.rb after 0 seconds
1 gem installed
```

when install in sudo mode:
```
hfli@CNhfli ~/Documents $ sudo /usr/bin/gem install --user redcarpet pygments.rb

Password:
Fetching: redcarpet-3.4.0.gem (100%)
WARNING:  You don't have /Users/hfli/.gem/ruby/2.3.0/bin in your PATH,
	  gem executables will not run.
Building native extensions.  This could take a while...
Successfully installed redcarpet-3.4.0
Parsing documentation for redcarpet-3.4.0
Installing ri documentation for redcarpet-3.4.0
Done installing documentation for redcarpet after 0 seconds
Fetching: pygments.rb-1.2.1.gem (100%)
Successfully installed pygments.rb-1.2.1
Parsing documentation for pygments.rb-1.2.1
Done installing documentation for pygments.rb after 0 seconds
2 gems installed
```