### PR TITLE
Code blocks: Add support for SPARQL

### DIFF
--- a/Snippets/Code block.tmSnippet
+++ b/Snippets/Code block.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>\`\`\`${1|ada,adb,ads,antlr,applescript,bash,bib,c,c#,c++,cmake,cpp,csharp,css,dot,fish,g4,go,groovy,grt,gtpl,gv,gvy,haskell,hs,html,inc,java,javascript,jruby,js,json,latex,lua,macruby,make,Makefile,Markdown,matlab,md,node,ocaml,octave,perl,php,pl,prolog,py,python,r,R,rake,rb,rbx,ruby,rusthon,scpt,sh,shell,sql,swift,tcl,Tcl,tex,vhd,vhdl,VHDL,xhtml,yaml,yml,zsh|}
+	<string>\`\`\`${1|ada,adb,ads,antlr,applescript,bash,bib,c,c#,c++,cmake,cpp,csharp,css,dot,fish,g4,go,groovy,grt,gtpl,gv,gvy,haskell,hs,html,inc,java,javascript,jruby,js,json,latex,lua,macruby,make,Makefile,Markdown,matlab,md,node,ocaml,octave,perl,php,pl,prolog,py,python,r,R,rake,rb,rbx,ruby,rusthon,scpt,sh,shell,sparql,sql,swift,tcl,Tcl,tex,vhd,vhdl,VHDL,xhtml,yaml,yml,zsh|}
 $0
 \`\`</string>
 	<key>name</key>

--- a/Syntaxes/Markdown (GitHub).tmLanguage
+++ b/Syntaxes/Markdown (GitHub).tmLanguage
@@ -1306,6 +1306,44 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(^|\G)\s*([`~]{3,})\s*(sparql)\s*$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.raw.begin.markdown</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.language.markdown</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>source.sparql</string>
+			<key>end</key>
+			<string>(^|\G)\s*(\2)\n?</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.raw.end.markdown</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>markup.raw.block.sparql</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.sparql</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(^|\G)\s*([`~]{3,})\s*(sql)\s*$</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
The [Turtle bundle](https://github.com/peta/turtle.tmbundle) provides a SPARQL grammar. Unfortunately, the current version of the grammar doesn’t work well inside code blocks, but I’ve already submitted a PR: https://github.com/peta/turtle.tmbundle/pull/13

