### PR TITLE
Add support for Crystal code blocks

### DIFF
--- a/Snippets/Code block.tmSnippet
+++ b/Snippets/Code block.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>\`\`\`${1|ada,adb,ads,antlr,applescript,bash,bib,c,c#,c++,cmake,cpp,csharp,css,dot,fish,g4,go,groovy,grt,gtpl,gv,gvy,haskell,hs,html,inc,java,javascript,jruby,js,json,latex,lua,macruby,make,Makefile,Markdown,matlab,md,node,ocaml,octave,perl,php,pl,prolog,py,python,r,R,rake,rb,rbx,ruby,rusthon,scpt,sh,shell,sparql,sql,swift,tcl,Tcl,tex,vhd,vhdl,VHDL,xhtml,yaml,yml,zsh|}
+	<string>\`\`\`${1|ada,adb,ads,antlr,applescript,bash,bib,c,c#,c++,cmake,cpp,crystal,csharp,css,dot,fish,g4,go,groovy,grt,gtpl,gv,gvy,haskell,hs,html,inc,java,javascript,jruby,js,json,latex,lua,macruby,make,Makefile,Markdown,matlab,md,node,ocaml,octave,perl,php,pl,prolog,py,python,r,R,rake,rb,rbx,ruby,rusthon,scpt,sh,shell,sparql,sql,swift,tcl,Tcl,tex,vhd,vhdl,VHDL,xhtml,yaml,yml,zsh|}
 $0
 \`\`</string>
 	<key>name</key>

--- a/Syntaxes/Markdown (GitHub).tmLanguage
+++ b/Syntaxes/Markdown (GitHub).tmLanguage
@@ -242,6 +242,44 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(^|\G)\s*([`~]{3,})\s*(crystal|cr)\s*$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.raw.begin.markdown</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.language.markdown</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>source.crystal</string>
+			<key>end</key>
+			<string>(^|\G)\s*(\2)\n?</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.raw.end.markdown</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>markup.raw.block.crystal</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.crystal</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(^|\G)\s*([`~]{3,})\s*(dot|gv)\s*$</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
Add support for [Crystal](https://crystal-lang.org/) code blocks.

<img width="1146" alt="Screenshot 2021-07-12 at 09 25 43" src="https://user-images.githubusercontent.com/503025/125247351-23c55f80-e2f3-11eb-9ee6-7567b545ebab.png">
