### PR TITLE
use env ruby instead of hard-coding system ruby

### DIFF
--- a/Support/bin/redcarpet.rb
+++ b/Support/bin/redcarpet.rb
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/env ruby
 # Usage: markdown-github.rb [<file>...]
 # Convert one or more GitHub Flavored Markdown files to HTML and print to
 # standard output. With no <file> or when <file> is "-", read GitHub Flavored


### PR DESCRIPTION
Self-explanatory, I think. The system ruby should not be used, let alone hard-coded for; certainly no gems should be installed in it. What ruby to use is up to the user, and `env` will reveal what it is.